### PR TITLE
[bugfix]: Broken links in blocking methods are fixed

### DIFF
--- a/src/content/docs/en/blocking/Method/dns-hijacking.md
+++ b/src/content/docs/en/blocking/Method/dns-hijacking.md
@@ -18,9 +18,9 @@ DNS hijacking typically targets DNS resolvers provided by the ISP itself. Howeve
 
 This type of block could be detected by many censorship checking software and services, such as:
 >
- - [GlobalCheck](/balefire/censorship/services/globalcheck/)
- - [RIPE Atlas](/balefire/censorship/services/ripe-atlas/)
- - [OONI Probe](/balefire/censorship/toolkits/ooni/)
+ - [GlobalCheck](/balefire/en/censorship/services/globalcheck/)
+ - [RIPE Atlas](/balefire/en/censorship/services/ripe-atlas/)
+ - [OONI Probe](/balefire/en/censorship/toolkits/ooni/)
 
 As well as manually:
 >

--- a/src/content/docs/en/blocking/Method/dpi-application-filtering.md
+++ b/src/content/docs/en/blocking/Method/dpi-application-filtering.md
@@ -12,7 +12,7 @@ This kind of block is difficult to detect and analyze. There’s no fully automa
 
 Selected application filtering test is supported in:
 >
- - [OONI Probe](/balefire/censorship/toolkits/ooni/)
+ - [OONI Probe](/balefire/en/censorship/toolkits/ooni/)
 
 General manual steps are as follows:
 >

--- a/src/content/docs/en/blocking/Method/https-sni-filtering.md
+++ b/src/content/docs/en/blocking/Method/https-sni-filtering.md
@@ -18,8 +18,8 @@ Typical errors you may encounter in a browser in case of SNI filtering:
  - (sometimes) **HTTPS certificate error**: his error points to issues with the HTTPS certificate, such as expiration, an untrusted certificate authority, or a mismatch between the domain and the certificate. It can also occur due to traffic interception altering the certificate.
 
 This type of block could be detected by some of censorship checking software (see SOFTWARE TOOLKITS), such as:
- - [OONI Probe](/balefire/censorship/toolkits/ooni/)
- - [RIPE Atlas](/balefire/censorship/services/ripe-atlas/) with 2 measurements: one with the original domain name and another one with the different, connecting the the same IP address
+ - [OONI Probe](/balefire/en/censorship/toolkits/ooni/)
+ - [RIPE Atlas](/balefire/en/censorship/services/ripe-atlas/) with 2 measurements: one with the original domain name and another one with the different, connecting the the same IP address
  - [blockcheck.sh](https://github.com/bol-van/zapret/blob/master/blockcheck.sh) script from “zapret” application
 
 As well as manually, by connecting to the same website using different domain name in HTTPS request:

--- a/src/content/docs/en/blocking/Method/ip-blackhole.md
+++ b/src/content/docs/en/blocking/Method/ip-blackhole.md
@@ -15,9 +15,9 @@ In the end, you may encounter the following browser error:
 
 This type of block could be detected by many censorship checking software and services, such as:
 >
- - [GlobalCheck](/balefire/censorship/services/globalcheck/)
- - [RIPE Atlas](/balefire/censorship/services/ripe-atlas/)
- - [OONI Probe](/balefire/censorship/toolkits/ooni/)
+ - [GlobalCheck](/balefire/en/censorship/services/globalcheck/)
+ - [RIPE Atlas](/balefire/en/censorship/services/ripe-atlas/)
+ - [OONI Probe](/balefire/en/censorship/toolkits/ooni/)
 
 As well as manually:
 >


### PR DESCRIPTION
Fixing 👇
Error: 9 [ERROR] ✗ Found 9 invalid links in 4 files.
12:43:59 ▶ balefire/en/blocking/method/dns-hijacking/
12:43:59   ├─ /balefire/censorship/services/globalcheck/ - invalid link
12:43:59   ├─ /balefire/censorship/services/ripe-atlas/ - invalid link
12:43:59   └─ /balefire/censorship/toolkits/ooni/ - invalid link
12:43:59 ▶ balefire/en/blocking/method/dpi-application-filtering/
12:43:59   └─ /balefire/censorship/toolkits/ooni/ - invalid link
12:43:59 ▶ balefire/en/blocking/method/https-sni-filtering/
12:43:59   ├─ /balefire/censorship/toolkits/ooni/ - invalid link
12:43:59   └─ /balefire/censorship/services/ripe-atlas/ - invalid link
12:43:59 ▶ balefire/en/blocking/method/ip-blackhole/
12:43:59   ├─ /balefire/censorship/services/globalcheck/ - invalid link
12:43:59   ├─ /balefire/censorship/services/ripe-atlas/ - invalid link
12:43:59   └─ /balefire/censorship/toolkits/ooni/ - invalid link